### PR TITLE
replaced merge() occurrences with extend()

### DIFF
--- a/dist/angular-ismobile.js
+++ b/dist/angular-ismobile.js
@@ -141,7 +141,7 @@
 	angular.module('ismobile').provider('isMobile', ['$windowProvider', function IsMobileProvider($windowProvider) {
 		var _window = $windowProvider.$get();
 
-		angular.merge(this, _window.isMobile);
+		angular.extend(this, _window.isMobile);
 
 		this.$get = [function isMobileFactory() {
 			return angular.copy(_window.isMobile);

--- a/dist/angular-ismobile.min.js
+++ b/dist/angular-ismobile.min.js
@@ -29,4 +29,4 @@ define("isMobile",[],a.isMobile=s()):a.isMobile=s()}(this),/**
  *
  * https://github.com/ronnyhaase/angular-ismobile
  */
-function(){"use strict";angular.module("ismobile",[]),angular.module("ismobile").provider("isMobile",["$windowProvider",function(a){var b=a.$get();angular.merge(this,b.isMobile),this.$get=[function(){return angular.copy(b.isMobile)}]}])}();
+function(){"use strict";angular.module("ismobile",[]),angular.module("ismobile").provider("isMobile",["$windowProvider",function(a){var b=a.$get();angular.extend(this,b.isMobile),this.$get=[function(){return angular.copy(b.isMobile)}]}])}();

--- a/src/ismobile.js
+++ b/src/ismobile.js
@@ -15,7 +15,7 @@
 	angular.module('ismobile').provider('isMobile', ['$windowProvider', function IsMobileProvider($windowProvider) {
 		var _window = $windowProvider.$get();
 
-		angular.merge(this, _window.isMobile);
+		angular.extend(this, _window.isMobile);
 
 		this.$get = [function isMobileFactory() {
 			return angular.copy(_window.isMobile);


### PR DESCRIPTION
`merge()` is not a function in AngularJS < 1.4.0. Without this replacement the `"angular"` dependency in [bower.json](https://github.com/ronnyhaase/angular-ismobile/blob/master/bower.json) should read  `">= 1.4.0"`, not `">= 1.2.0"`
